### PR TITLE
userおよびaffiliationの登録機能の実装に伴う、protocol登録機能の修正

### DIFF
--- a/app/assets/javascripts/custom_protocols.coffee
+++ b/app/assets/javascripts/custom_protocols.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/custom_protocols.scss
+++ b/app/assets/stylesheets/custom_protocols.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the custom_protocols controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/custom_protocols_controller.rb
+++ b/app/controllers/custom_protocols_controller.rb
@@ -1,0 +1,15 @@
+class CustomProtocolsController < ApplicationController
+  def index
+  end
+
+  def new
+    if params[:parent_id].present?
+      @protocol = Protocol.new(status: Protocl::CUSTOM, parent_id: params[:parent_id])
+    end
+    #elseに関しては別ブランチでrescueする処理作る。
+  end
+
+  def create
+  end
+
+end

--- a/app/controllers/protocols_controller.rb
+++ b/app/controllers/protocols_controller.rb
@@ -1,4 +1,5 @@
 class ProtocolsController < ApplicationController
+  before_action :authenticate_user!
 
   def index
   end
@@ -10,17 +11,10 @@ class ProtocolsController < ApplicationController
   end
 
   def new
-    # deviseでの実装が完了するまでのつなぎ。
-    current_user = 1
-    if current_user = 1
-    #if current_user.status = 1
+    if current_user.admin = true
       @protocol = Protocol.new(status: Protocol::TEMPLATE)
     else
-      if params[:parent_id].present?
-        @protocol = Protocol.new(status: Protocl::CUSTOM, parent_id: params[:parent_id])
-      else
-        @protocol = Protocol.new
-      end
+      @protocol = Protocol.new
     end
 
     @protocol.procedures.build
@@ -28,9 +22,8 @@ class ProtocolsController < ApplicationController
 
   def create
     protocol = Protocol.new(create_params)
-    # 以下の記述は菊池氏の作業が終わり次第戻す
-    # protocol.affiliation_id = current_user.affiliation.id
-    # protocol.user_id = current_user.id
+    protocol.affiliation_id = current_user.affiliation.id
+    protocol.user_id = current_user.id
     protocol.save
   end
 

--- a/app/helpers/custom_protocols_helper.rb
+++ b/app/helpers/custom_protocols_helper.rb
@@ -1,0 +1,2 @@
+module CustomProtocolsHelper
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,7 +13,6 @@ Rails.application.routes.draw do
   end
 
   root 'protocols#new'
-  devise_for :users
 
   #ログイン＆新規登録画面
     #root 'users#index'

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,16 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_17_154116) do
+ActiveRecord::Schema.define(version: 2019_02_03_115759) do
 
   create_table "affiliations", options: "ENGINE=MyISAM DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "university", default: "", null: false
     t.string "department", default: "", null: false
     t.string "course", default: "", null: false
     t.string "labo", default: "", null: false
+    t.string "cord", default: "", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "cord", null: false
   end
 
   create_table "comments", options: "ENGINE=MyISAM DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -79,12 +79,12 @@ ActiveRecord::Schema.define(version: 2019_02_17_154116) do
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
     t.string "first_name", default: "", null: false
-    t.string "last_name", default: "0", null: false
+    t.string "last_name", default: "", null: false
     t.bigint "affiliation_id"
     t.string "avatar", default: "", null: false
+    t.boolean "admin", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.boolean "admin", default: false, null: false
     t.index ["affiliation_id"], name: "index_users_on_affiliation_id"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true

--- a/test/controllers/custom_protocols_controller_test.rb
+++ b/test/controllers/custom_protocols_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class CustomProtocolsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
userおよびaffiliationの登録機能の実装に伴い、protocol登録機能に修正を加えた。
今のところはtemprateプロトコルとbase　プロトコルの登録機能のみ。
custom_protocolに関しては、別ブランチでの実装を予定。

確認が完了したのち、素早くマージしたい案件。