### PR TITLE
fix: display image

### DIFF
--- a/app/assets/stylesheets/main.css
+++ b/app/assets/stylesheets/main.css
@@ -174,7 +174,10 @@ header{
   padding: 20px 10px;
 }
 
-
+/*プロトコルのリンクボタンのレイアウト*/
+.transition-btn-wrapper {
+  text-align: center;
+}
 
 
 /*--------登録完了画面----------*/

--- a/app/controllers/experiment_controller.rb
+++ b/app/controllers/experiment_controller.rb
@@ -38,7 +38,6 @@ class ExperimentController < ApplicationController
     @experiment = current_user.experiments.build(experiment_params)
     @experiment[:affiliation_id] = current_user.affiliation_id
     new_category_save if !@experiment.new_category.empty?
-    binding.pry
     if @experiment.save
       flash[:notice] = "実験結果が登録されました。"
       redirect_to experiment_show_path(@experiment)

--- a/app/controllers/experiment_controller.rb
+++ b/app/controllers/experiment_controller.rb
@@ -38,12 +38,13 @@ class ExperimentController < ApplicationController
     @experiment = current_user.experiments.build(experiment_params)
     @experiment[:affiliation_id] = current_user.affiliation_id
     new_category_save if !@experiment.new_category.empty?
+    binding.pry
     if @experiment.save
       flash[:notice] = "実験結果が登録されました。"
       redirect_to experiment_show_path(@experiment)
     else
       flash[:alert] = 'エラーが発生しました。'
-      render 'new'
+      redirect_back(fallback_location: root_path)
     end
   end
   

--- a/app/views/experiment/new.html.erb
+++ b/app/views/experiment/new.html.erb
@@ -71,9 +71,7 @@
                     <%= text_field_tag :tag_list, @experiment.tag_list, :class => "form-control" %>
                   </div>
                 </div>    
-                <button class="btn btn-register">
-                  <%= f.submit "登録する", class: 'btn-Atag' %>
-                </button>
+                <%= f.submit "登録する", class: 'btn btn-outline-primary btn-register' %>
             <% end %>
           </div>
         </div>

--- a/app/views/experiment/new.html.erb
+++ b/app/views/experiment/new.html.erb
@@ -28,8 +28,8 @@
 
                 <div class="form-group col-md-5 mb-5">
                   <%= f.label :protocol_id, '利用したプロトコル'%>
-                  <%= @protocol.title, class: "form-control"  %>
-                  <%= f.hidden_field :protocol_id, @protocol.id %>
+                  <%= @protocol.title %>
+                  <%= f.hidden_field :protocol_id, value: @protocol.id %>
                 </div>
 
                 <div class="form-group mb-5">

--- a/app/views/experiment/show.html.erb
+++ b/app/views/experiment/show.html.erb
@@ -20,7 +20,7 @@
       <div class="container-fluid">        <!-- 全体を囲むコンテナ -->
           <div class="row justify-content-center">
             <div class="col-md-4">
-              <%#= image_tag @experiment.image.url, class: "img-fluid", style: "height: 200px; width: auto; border-radius: 5px;" %>
+              <%= image_tag @experiment.image.url, class: "img-fluid", style: "height: 200px; width: auto; border-radius: 5px;" %>
             </div>
             <div class="col-md-6 mt-4 mt-md-0">
               <p class="experiment-time">実験実施日<br>

--- a/app/views/protocols/show.html.erb
+++ b/app/views/protocols/show.html.erb
@@ -47,9 +47,17 @@
           <div class="row justify-content-center">
             <div class="col-0"></div>
               <div class="col-10">
-                <%= link_to "これをカスタム
-                ", custom_new_path(parent_id: @protocol.id), class: "btn btn-outline-primary" %>
-            </div>
+                <div class="row">
+                  <div class="col-6 transition-btn-wrapper">
+                    <%= link_to "これをカスタム
+                    ", custom_new_path(parent_id: @protocol.id), class: "btn btn-outline-primary" %>
+                  </div>
+                  <div class="col-6 transition-btn-wrapper">
+                    <%= link_to "実験結果を登録
+                    ", new_experiment_path(protocol_id: @protocol.id), class: "btn btn-outline-primary" %>
+                  </div>
+                </div>
+              </div>
           </div>
         </div>
       </div>                <!-- 全体を囲むコンテナ -->


### PR DESCRIPTION
実験結果の登録に関して以下2点の問題を修正
・プロトコルから実験結果を登録することができない。
・実験結果に画像が表示されない。

一点目に関しては、 `protocol/show` に「実験結果を作成」を追加し、実験結果の作成ページへのリンクとした。
2点目に関しては単純に実装が止まっていただけの模様。
変更点は少ないっす。